### PR TITLE
Made BookStack uploads folder volumable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,7 @@ services:
     - DB_DATABASE=bookstack
     - DB_USERNAME=bookstack
     - DB_PASSWORD=secret
+    volumes:
+    - ./uploads:/var/www/BookStack/public/uploads
     ports:
     - "8080:80"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -78,4 +78,6 @@ fi
 
 cd /var/www/BookStack/ && php artisan key:generate && php artisan migrate --force
 
+chown -R www-data:www-data /var/www/BookStack/public/uploads && chmod -R 775 /var/www/BookStack/public/uploads
+
 exec apache2-foreground


### PR DESCRIPTION
Thought it would be a good idea to make the uploads folder into a volume so that they can persist like the MySQL data. This makes them easier to back up and it also becomes easier to share the uploads between multiple BookStack docker instances (Not a common requirement but it's fun to see in action). Unfortunately this does require forcing permissions on the upload folder every startup, Hence the entrypoint script change. 

I'm not sure how this affects your docker image versioning (I've never published docker images). If it helps I'm likely to be releasing another BookStack bugfix release this weekend which will bump BookStack to version v0.11.2 so this could be merged with that version change if it makes things easier.
