### PR TITLE
Added php.ini to docker image so that users can upload above 10MB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y git zlib1g-dev libfreetype6-dev libjpeg
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/* /var/tmp/* /etc/apache2/sites-enabled/000-*.conf
 
+COPY php.ini /usr/local/etc/php/php.ini
 COPY bookstack.conf /etc/apache2/sites-enabled/bookstack.conf
 RUN a2enmod rewrite
 

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,4 @@
+[PHP]
+
+post_max_size = 10M
+upload_max_filesize = 10M


### PR DESCRIPTION
PHP limits uploads to 2MB by default and this prevents even reasonably sized attachments to pages to be added to the server. The added php.ini increases the limit to 10MB.