### PR TITLE
Upgrade PHP to 7.1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0-apache
+FROM php:7.1.10-apache
 
 ENV BOOKSTACK=BookStack \
     BOOKSTACK_VERSION=0.18.2 \


### PR DESCRIPTION
Currently is `7.1+` is the new stable version so let's see how it's working out on bookstack.