### PR TITLE
Add mail from address settings in .env file

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -77,6 +77,8 @@ if [ ! -f "$BOOKSTACK_HOME/.env" ]; then
       MAIL_USERNAME=${MAIL_USERNAME:-null}
       MAIL_PASSWORD=${MAIL_PASSWORD:-null}
       MAIL_ENCRYPTION=${MAIL_ENCRYPTION:-null}
+      MAIL_FROM=${MAIL_FROM:-null}
+      MAIL_FROM_NAME=${MAIL_FROM_NAME:-null}
       # URL used for social login redirects, NO TRAILING SLASH
 EOF
 sed -ie "s/single/errorlog/g" config/app.php


### PR DESCRIPTION
This pull request allow to specify a name and address that is used globally for all e-mails that are sent by Bookstack. In some mail setups, mail spoofing is denied, each user may only send with his own or his alias addresses. In this specific case, this environment variables are required. 

My postfix setup rejects when the noreply address sends an email as `mail@bookstackapp.com` which is the default one with your docker image.

```
reject: RCPT from docker[x.x.x.x]: 553 5.7.1 <mail@bookstackapp.com>: Sender address rejected: not owned by user noreply@domain.tld; from=<mail@bookstackapp.com> to=<user@domain.tld> proto=ESMTP helo=<bookstack.domain.tld>
```

[BookStack/config/mail.php#L46-L57](https://github.com/BookStackApp/BookStack/blob/b0d027a4a9f6b139bdfe697aabffaba5eeaaa5ba/config/mail.php#L46-L57)