### PR TITLE
Implement swarm style secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV BOOKSTACK=BookStack \
     BOOKSTACK_VERSION=0.21.0 \
     BOOKSTACK_HOME="/var/www/bookstack"
 
-RUN apt-get update && apt-get install -y git zlib1g-dev libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev wget libldap2-dev libtidy-dev \
+RUN apt-get update && apt-get install -y git zlib1g-dev libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev wget libldap2-dev libtidy-dev \
    && docker-php-ext-install pdo pdo_mysql mbstring zip tidy \
    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
    && docker-php-ext-install ldap \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,22 +30,22 @@ file_env() {
 IFS=":" read -r DB_HOST_NAME DB_PORT <<< "$DB_HOST"
 DB_PORT=${DB_PORT:-3306}
 
-file_env 'DB_HOST'      'localhost'
-file_env 'DB_DATABASE'  'bookstack'
-file_env 'DB_USERNAME'  'bookstack'
-file_env 'DB_PASSWORD'  'password'
-file_env 'APP_KEY'      'SomeRandomStringWith32Characters'
-file_env 'TORAGE_S3_KEY' 'false'
-file_env 'STORAGE_S3_SECRET' 'false'
-file_env 'STORAGE_S3_REGION' 'false'
-file_env 'STORAGE_S3_BUCKET' 'false'
-file_env 'GITHUB_APP_ID' 'false'
-file_env 'GITHUB_APP_SECRET' 'false'
-file_env 'GOOGLE_APP_ID' 'false'
-file_env 'GOOGLE_APP_SECRET' 'false'
-file_env 'LDAP_PASS' 'false'
-file_env 'MAIL_USERNAME' 'null'
-file_env 'MAIL_PASSWORD' 'null'
+file_env 'DB_HOST'      	'localhost'
+file_env 'DB_DATABASE'  	'bookstack'
+file_env 'DB_USERNAME'  	'bookstack'
+file_env 'DB_PASSWORD'  	'password'
+file_env 'APP_KEY'      	'SomeRandomStringWith32Characters'
+file_env 'TORAGE_S3_KEY' 	'false'
+file_env 'STORAGE_S3_SECRET' 	'false'
+file_env 'STORAGE_S3_REGION' 	'false'
+file_env 'STORAGE_S3_BUCKET' 	'false'
+file_env 'GITHUB_APP_ID' 	'false'
+file_env 'GITHUB_APP_SECRET' 	'false'
+file_env 'GOOGLE_APP_ID' 	'false'
+file_env 'GOOGLE_APP_SECRET' 	'false'
+file_env 'LDAP_PASS' 		'false'
+file_env 'MAIL_USERNAME' 	'null'
+file_env 'MAIL_PASSWORD' 	'null'
 
 if [ ! -f "$BOOKSTACK_HOME/.env" ]; then
   if [[ "${DB_HOST}" ]]; then


### PR DESCRIPTION
Hi all, first off thanks for the great image&software.

I'm trying to get a copy of bookstack running on a swarm setup, thereby also storing passwords in swarm's secrets feature. Basicly this means that the passwords are exposed via a file in `/run/secrets/secret-name`, rather then exporting the passwords via environment variables.

[Postgres's container implements this feature by using a simple(?) bash function ](https://github.com/docker-library/postgres/blob/master/11/docker-entrypoint.sh#L5)in their entrypoint script; basicly any environment variable can be replaced with a `_FILE` variant; which gets read automatically
```bash
# usage: file_env VAR [DEFAULT]
#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
file_env() {
	local var="$1"
	local fileVar="${var}_FILE"
	local def="${2:-}"
	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
		exit 1
	fi
	local val="$def"
	if [ "${!var:-}" ]; then
		val="${!var}"
	elif [ "${!fileVar:-}" ]; then
		val="$(< "${!fileVar}")"
	fi
	export "$var"="$val"
	unset "$fileVar"
}
```
[Which is simply used ](hhttps://github.com/docker-library/postgres/blob/master/11/docker-entrypoint.sh#L82)as `file_env 'POSTGRES_PASSWORD'` before doing anything with the actual variable.

So I have implemented this function for several variables, that seem appropriate.