### PR TITLE
remove hardcoded ldap libdir in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV BOOKSTACK=BookStack \
 
 RUN apt-get update && apt-get install -y git zlib1g-dev libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev wget libldap2-dev libtidy-dev \
    && docker-php-ext-install pdo pdo_mysql mbstring zip tidy \
-   && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+   && docker-php-ext-configure ldap \
    && docker-php-ext-install ldap \
    && docker-php-ext-configure gd --with-freetype-dir=usr/include/ --with-jpeg-dir=/usr/include/ \
    && docker-php-ext-install gd \


### PR DESCRIPTION
I found this repo to be regularly updated (thank you!) and thus I am using it to host a bookstack container on raspberry pi. For this purpose, I am rebuilding the image on the device with the Dockerfile provided. It works flawless despite one line:
https://github.com/solidnerd/docker-bookstack/blob/2ccba9ae54814194e858f0a6bdd95f986d09bbd1/Dockerfile#L9

Obviously, the path lib/x86_64-linux-gnu does not exist on arm architecture. Removing the argument results in a successful build both on arm as well as amd64 systems.
As far as I see, the argument can be omitted to gain compatibility for arm. Let me know if I am missing anything.