### PR TITLE
make max execution time visible in php.ini

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -2,3 +2,4 @@
 
 post_max_size = 10M
 upload_max_filesize = 10M
+max_execution_time = 30


### PR DESCRIPTION
as I have tried to export rather large "books", I often exceeded that 30 seconds, so it should be visible here for anyone willing to change it.