### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     - DB_PASSWORD=secret
     volumes:
     - uploads:/var/www/bookstack/public/uploads
-    - storage-uploads:/var/www/bookstack/public/storage
+    - storage-uploads:/var/www/bookstack/storage/uploads
     ports:
     - "8080:80"
 


### PR DESCRIPTION
To avoid uploaded file storage into docker filesystem
According official documentation (https://www.bookstackapp.com/docs/admin/upload-config/) set storage-uploads to /var/www/bookstack/storage/uploads instead of /var/www/bookstack/public/storage