### PR TITLE
BookStack update, storage path fix and new env variables. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR $BOOKSTACK_HOME
 
 EXPOSE 80
 
-VOLUME ["$BOOKSTACK_HOME/public/uploads","$BOOKSTACK_HOME/public/storage"]
+VOLUME ["$BOOKSTACK_HOME/public/uploads","$BOOKSTACK_HOME/storage/uploads"]
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.1-apache-stretch
 
 ENV BOOKSTACK=BookStack \
-    BOOKSTACK_VERSION=0.25.2 \
+    BOOKSTACK_VERSION=0.26.1 \
     BOOKSTACK_HOME="/var/www/bookstack"
 
 RUN apt-get update && apt-get install -y git zlib1g-dev libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev wget libldap2-dev libtidy-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y git zlib1g-dev libfreetype6-dev libjpeg
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/* /var/tmp/* /etc/apache2/sites-enabled/000-*.conf
 
-COPY php.ini /usr/local/etc/php/php.ini
+
 COPY bookstack.conf /etc/apache2/sites-enabled/bookstack.conf
 RUN a2enmod rewrite
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     - DB_PASSWORD=secret
     volumes:
     - uploads:/var/www/bookstack/public/uploads
-    - storage-uploads:/var/www/bookstack/public/storage
+    - storage-uploads:/var/www/bookstack/storage/uploads
     ports:
     - "8080:80"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     - mysql-data:/var/lib/mysql
 
   bookstack:
-    image: solidnerd/bookstack:0.25.2
+    image: solidnerd/bookstack:0.26.1
     depends_on:
     - mysql
     environment:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -78,12 +78,25 @@ if [ ! -f "$BOOKSTACK_HOME/.env" ]; then
       MAIL_PASSWORD=${MAIL_PASSWORD:-null}
       MAIL_ENCRYPTION=${MAIL_ENCRYPTION:-null}
       # URL used for social login redirects, NO TRAILING SLASH
+
+      # Language Configuration
+      APP_LANG=${APP_LANG:-en}
+      APP_AUTO_LANG_PUBLIC=${APP_AUTO_LANG_PUBLIC:-true}
 EOF
 sed -ie "s/single/errorlog/g" config/app.php
     else
         echo >&2 'error: missing DB_HOST environment variable'
         exit 1
     fi
+fi
+
+if [ ! -f "/usr/local/etc/php/php.ini" ]; then
+  cat > "/usr/local/etc/php/php.ini" <<EOF
+[PHP]
+
+post_max_size = ${post_max_size:-10M}
+upload_max_filesize = ${upload_max_filesize:-10M}
+EOF
 fi
 
 echoerr "wait-for-db: waiting for ${DB_HOST_NAME}:${DB_PORT}"


### PR DESCRIPTION
BookStack update to 0.26.1 version. Fixed wrong path for file uploads. Added variables for language configuration and moved php.ini to docker-entrypoint.sh, to be able configure upload sizes with docker-compose file. 