### PR TITLE
Added Trap to pervent container crashing

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -118,4 +118,5 @@ php artisan cache:clear
 
 php artisan view:clear
 
+trap "echo Catching SIGWINCH apache error and perventing it." SIGWINCH
 exec apache2-foreground


### PR DESCRIPTION
We have been running bookstack last couple of months in prod, for our companies. We noticed the container would crash. Normally I would restart the Pod within kubernetes which would fix the issue sometimes. It very intermittent.
Capture
![Capture](https://user-images.githubusercontent.com/968709/75003107-af0b3000-5434-11ea-8bd7-3da40c758deb.PNG)

Crash is caused by WINCH which Graceful Stop, when running apache in the foreground.
http://httpd.apache.org/docs/2.2/stopping.html#gracefulstop
Suggested Fix:
trap "echo Catching SIGWINCH apache error and perventing it." SIGWINCH

This has fixed the issues and we do not experience this error anymore.