### PR TITLE
Add APP_URL to dockercompose and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,14 @@ docker run -d --net bookstack_nw \
 -e DB_DATABASE=bookstack \
 -e DB_USERNAME=bookstack \
 -e DB_PASSWORD=secret \
+-e APP_URL=http://example.com \
 -p 8080:8080 \
 --name="bookstack_21.12" \
  solidnerd/bookstack:21.12
 ```
+
+The APP_URL parameter should be the base URL for your BookStack instance without a trailing slash. For example:
+APP_URL=http://example.com
 
 #### Volumes
 To access your `.env` file and important bookstack folders on your host system change `<HOST>` in the following line to your host directory and add it then to your run command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     - DB_DATABASE=bookstack
     - DB_USERNAME=bookstack
     - DB_PASSWORD=secret
+    #set the APP_ to the URL of bookstack without without a trailing slash APP_URL=https://example.com
+    - APP_URL=http://example.com
     volumes:
     - uploads:/var/www/bookstack/public/uploads
     - storage-uploads:/var/www/bookstack/storage/uploads


### PR DESCRIPTION
As I run in to the problem that we now have to specify the APP_URL for the bookstack container I thought it would be nice to reflect that in the Repo
fixes #289