### PR TITLE
Fixed the issue "Without index output to the exported PDF file."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,20 @@ RUN set -x; \
         libxml2-dev  \
         fontconfig  \
         fonts-freefont-ttf   \
-        wkhtmltopdf  \
+        wget \
         tar \
         curl \
         libzip-dev \
         unzip \
-    \
-   && docker-php-ext-install -j$(nproc) dom pdo pdo_mysql zip tidy  \
-   && docker-php-ext-configure ldap \
-   && docker-php-ext-install -j$(nproc) ldap \
-   && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
-   && docker-php-ext-install -j$(nproc) gd
+	&& wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb \
+	&& chmod a+x ./wkhtmltox_0.12.6-1.buster_amd64.deb \
+    && apt-get install -y ./wkhtmltox_0.12.6-1.buster_amd64.deb \
+    && rm ./wkhtmltox_0.12.6-1.buster_amd64.deb \
+    && docker-php-ext-install -j$(nproc) dom pdo pdo_mysql zip tidy  \
+    && docker-php-ext-configure ldap \
+    && docker-php-ext-install -j$(nproc) ldap \
+    && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
 
 RUN a2enmod rewrite remoteip; \
     { \


### PR DESCRIPTION
Fixed the issue "Without index output to the exported PDF file."

Issue reproduce:
1) checkout latest release 21.12.1
2) launch it with command: docker-compose up -d
3) login, create one page, append multi depth level Headers and sub Headers, and saved the page.
4) click the export pdf to download the pdf of the page. Check it with any pdf viewer, but can not find any index of the page Headers.

Issue trace:
1) attach into the shell of bookstack container as root user.
2) execute the following command and got errors:
`
root@0a7ea8351174:/usr/bin# wkhtmltopdf --outline toc https://doc.qt.io/archives/qt-4.8/qstring.html qstring.pdf
The switch --outline, is not support using unpatched qt, and will be ignored.QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
Error: This version of wkhtmltopdf is built against an unpatched version of QT, and does not support more than one input document.
Exit with code 1, due to unknown error.
root@0a7ea8351174:/usr/bin# 

`

Try to fix the issue:
docker exec -u root -it docker-bookstack_bookstack_1 /bin/bash
1) apt-get update
2) apt-get purge wkhtmlto pdf
3) apt-get install wget
4) wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb 
5) chmod a+x ./wkhtmltox_0.12.6-1.buster_amd64.deb
6) apt-get install -y ./wkhtmltox_0.12.6-1.buster_amd64.deb
7) confirm fixing as following steps:
`
ray@TF:/mnt/n03/github/falcon/docker-bookstack$ docker exec -u root -it docker-bookstack_bookstack_1 /bin/bash

root@c594b64fbcdf:/var/www/bookstack# cd /

root@c594b64fbcdf:/# which wkhtmltopdf
/usr/local/bin/wkhtmltopdf

root@c594b64fbcdf:/# wkhtmltopdf --outline toc https://doc.qt.io/archives/qt-4.8/qstring.html qstring.pdf
Loading pages (1/6)
Error: Failed to load https://doc.qt.io/archives/qt-4.8/.exclude-promos, with network status code 203 and http status code 404 - Error downloading https://doc.qt.io/archives/qt-4.8/.exclude-promos - server replied: Not Found
Error: Failed to load https://stats.g.doubleclick.net/j/collect?t=dc&aip=1&_r=3&v=1&_v=j96&tid=UA-54043535-2&cid=1481849754.1648017330&jid=171526614&gjid=1061804137&_gid=1005382051.1648017330&_u=YEBAAQAAAAAAAC~&z=220685795, with network status code 3 and http status code 0 - Host  not found
[=====================================================>      ] 89%
Counting pages (2/6)                                               
Loading TOC (3/6)                                                           
Resolving links (4/6)                                              
Loading headers and footers (5/6)                                           
Printing pages (6/6)
Done                                                                        
Exit with code 1 due to network error: HostNotFoundError

root@c594b64fbcdf:/# 

`
    Even got errors again, but the unsupport error is fixed.
8) export the same page on bookstack and check it, with Index out now! 


    After that, I patched the solution into Dockerfile.



                                                                                                                     
