### PR TITLE
Add arm64 platforms for docker image release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm/v7,linux/arm64
         push: false
         tags: |
           ${{ steps.docker_meta_ci.outputs.tags }}
@@ -96,7 +96,7 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm/v7,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64,linux/arm/v7,linux/arm64
+        platforms: linux/amd64,linux/arm64
         push: false
         tags: |
           ${{ steps.docker_meta_ci.outputs.tags }}
@@ -96,7 +96,7 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64,linux/arm/v7,linux/arm64
+        platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ${{ steps.docker_meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,11 @@ RUN set -x; \
         curl \
         libzip-dev \
         unzip \
-	&& wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb \
-	&& chmod a+x ./wkhtmltox_0.12.6-1.buster_amd64.deb \
-    && apt-get install -y ./wkhtmltox_0.12.6-1.buster_amd64.deb \
-    && rm ./wkhtmltox_0.12.6-1.buster_amd64.deb \
+    && arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
+	&& wget "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_${arch}.deb" \
+	&& chmod a+x "./wkhtmltox_0.12.6-1.buster_${arch}.deb" \
+    && apt-get install -y "./wkhtmltox_0.12.6-1.buster_${arch}.deb" \
+    && rm "./wkhtmltox_0.12.6-1.buster_${arch}.deb" \
     && docker-php-ext-install -j$(nproc) dom pdo pdo_mysql zip tidy  \
     && docker-php-ext-configure ldap \
     && docker-php-ext-install -j$(nproc) ldap \


### PR DESCRIPTION
This pull request introduces `arm64` build in the Dockerfile and release pipeline.
Testing: I've self-built and published using buildx and it worked like a charm!