### PR TITLE
Add 'file_env' (Docker secret) support for database environment vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,28 @@
 
 ### Changes
 
-In 0.28.0 we changed the container http port from 80 to 8080 to allow root privileges to be dropped
-In 0.12.2 we removed `DB_PORT` . You can now specify the port via `DB_HOST` like `DB_HOST=mysql:3306`
+In 0.28.0 we changed the container http port from 80 to 8080 to allow root privileges to be dropped.
+In 0.12.2 we removed `DB_PORT`. You can now specify the port via `DB_HOST` like `DB_HOST=mysql:3306`
 
 ### Quickstart
 
-With Docker Compose is a Quickstart very easy. Run the following command:
+Docker Compose is the quickest way to start using BookStack. Run the following command:
 
 ```
-docker-compose up
+docker-compose up -d
 ```
 
-and after that open your Browser and go to [http://localhost:8080](http://localhost:8080) . You can login with username 'admin@admin.com' and password 'password'.
+and after that open your Browser and go to [http://localhost:8080](http://localhost:8080). You can login with username 'admin@admin.com' and password 'password'.
 
 ### Issues
 
 If you have any issues feel free to create an [issue on GitHub](https://github.com/solidnerd/docker-bookstack/issues).
 
+### Docker Secrets
+
+When using Docker compose, certain environment variables (DB\_HOST, DB\_DATABASE, DB\_USER, and DB\_PASSWORD) may be initialized as [Docker secrets](https://docs.docker.com/compose/compose-file/09-secrets/) to prevent their exposure within the docker-compose.yml file or via `docker inspect`. First, the values for each secret must be saved as individual files. Then, the docker-compose.yml file must be modified to correctly call these secrets. An example compose file is included at docker-compose.secrets.yml. Note that the environment variables listed above have been replaced with their \*\_FILE equivalents, and a new top-level "secrets" element has been added to the end of the file.
+
+Both the MySQL and MariaDB Docker implementations also support Docker secrets. See their documentation for details.
 
 ### How to use the Image without Docker compose
 

--- a/docker-compose.secrets.yml
+++ b/docker-compose.secrets.yml
@@ -1,0 +1,43 @@
+version: '2'
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+    - MYSQL_ROOT_PASSWORD=secret
+    - MYSQL_DATABASE=bookstack
+    - MYSQL_USER=bookstack
+    - MYSQL_PASSWORD=secret
+    volumes:
+    - mysql-data:/var/lib/mysql
+
+  bookstack:
+    image: solidnerd/bookstack:23.2.1
+    depends_on:
+    - mysql
+    environment:
+    - DB_HOST_FILE=/run/secrets/bookstack_db_host
+    - DB_DATABASE_FILE=/run/secrets/bookstack_db_database
+    - DB_USERNAME_FILE=/run/secrets/bookstack_db_username
+    - DB_PASSWORD_FILE=/run/secrets/bookstack_db_password
+    #set the APP_ to the URL of bookstack without without a trailing slash APP_URL=https://example.com
+    - APP_URL=http://example.com
+    volumes:
+    - uploads:/var/www/bookstack/public/uploads
+    - storage-uploads:/var/www/bookstack/storage/uploads
+    ports:
+    - "8080:8080"
+
+volumes:
+  mysql-data:
+  uploads:
+  storage-uploads:
+
+secrets:
+  bookstack_db_host:
+    file: /path/to/secret/file1
+  bookstack_db_database:
+    file: /path/to/secret/file2
+  bookstack_db_username:
+    file: /path/to/secret/file3
+  bookstack_db_password: 
+    file: /path/to/secret/file4


### PR DESCRIPTION
Enables use of Docker compose secrets to securely store DB_HOST, DB_DATABASE, DB_USER, and DB_PASSWORD environment variables if desired. Heavily based on MariaDB's implementation here: https://github.com/MariaDB/mariadb-docker/commit/6452a881b90283f46c88925b08c2d580a49a27cc.