### PR TITLE
Pass php.ini params as env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ docker run -d --net bookstack_nw \
  solidnerd/bookstack:23.2.3
 ```
 
+or using non default php.ini values:
+```bash
+docker run -d --net bookstack_nw \
+-e DB_HOST=bookstack_db:3306 \
+-e DB_DATABASE=bookstack \
+-e DB_USERNAME=bookstack \
+-e DB_PASSWORD=secret \
+-e APP_URL=http://example.com \
+-e PHP_POST_MAX_SIZE=100M \
+-e PHP_UPLOAD_MAX_FILESIZE=100M \
+-e PHP_MEMORY_LIMIT=256M \
+-p 8080:8080 \
+--name="bookstack_23.2.3" \
+ solidnerd/bookstack:23.2.3
+```
+
 The APP_URL parameter should be the base URL for your BookStack instance without a trailing slash. For example:
 APP_URL=http://example.com
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -25,6 +25,9 @@ services:
     - DB_DATABASE=bookstack
     - DB_USERNAME=bookstack
     - DB_PASSWORD=secret
+    - PHP_POST_MAX_SIZE=10M
+    - PHP_UPLOAD_MAX_FILESIZE=10M
+    - PHP_MEMORY_LIMIT=128M
     volumes:
     - uploads:/var/www/bookstack/public/uploads
     - storage-uploads:/var/www/bookstack/storage/uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,10 @@ services:
     - DB_PASSWORD=secret
     #set the APP_ to the URL of bookstack without without a trailing slash APP_URL=https://example.com
     - APP_URL=http://example.com
+    #set php.ini configuration values
+    - PHP_POST_MAX_SIZE=10M
+    - PHP_UPLOAD_MAX_FILESIZE=10M
+    - PHP_MEMORY_LIMIT=128M
     volumes:
     - uploads:/var/www/bookstack/public/uploads
     - storage-uploads:/var/www/bookstack/storage/uploads

--- a/php.ini
+++ b/php.ini
@@ -1,4 +1,5 @@
 [PHP]
 
-post_max_size = 10M
-upload_max_filesize = 10M
+post_max_size = ${PHP_POST_MAX_SIZE}
+upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}
+memory_limit = ${PHP_MEMORY_LIMIT}


### PR DESCRIPTION
By default php.ini limits are predefined in  - https://github.com/solidnerd/docker-bookstack/blob/master/php.ini and can't be easily changed.  If we want to set up custom values, for e.g. to upload bigger files 100m+ https://www.bookstackapp.com/docs/admin/upload-config/, we should create a custom image and maintenance it manually.

php.ini supports env variables as parameters - https://www.php.net/manual/en/configuration.file.php#example-36

```
; PHP_MEMORY_LIMIT is taken from environment
memory_limit = ${PHP_MEMORY_LIMIT}
```

Changes:
- Pass php.ini params as env variables

PHP.INI|Env Name|Default Value|
|---|------|---------------|
post_max_size|PHP_POST_MAX_SIZE|10M
upload_max_filesize|PHP_UPLOAD_MAX_FILESIZE|10M
memory_limit|PHP_MEMORY_LIMIT|128M
