### PR TITLE
Enable workflow 'latest' pushes for all tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
         # for this project. Note that _actual_ semver build info is not used,
         # as it is discarded by almost everything that consumes SemVer (as it
         # should be).
-        flavour: |
+        flavor: |
           latest=true
         tags: |
           type=semver,pattern={{version}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,11 @@ jobs:
         images: |
           solidnerd/bookstack
           ghcr.io/solidnerd/docker-bookstack
+        # Blanket-enable "latest" tagging for all of the releases that make it
+        # this far, as SemVer's pre-release tag is used as a build indicator
+        # for this project. Note that _actual_ semver build info is not used,
+        # as it is discarded by almost everything that consumes SemVer (as it
+        # should be).
         flavour: |
           latest=true
         tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
         images: |
           solidnerd/bookstack
           ghcr.io/solidnerd/docker-bookstack
+        flavour: |
+          latest=true
         tags: |
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
As "pre-release" version tags are used to indicate builds of the Docker container around Bookstack's version IDs, it makes sense for the latest release to also feature the latest tag on Docker hub and the GHCR.

See #410 for more