### PR TITLE
Correct BOOKSTACK_VERSION in Dockerfile for 24.02.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3 as bookstack
-ENV BOOKSTACK_VERSION=23.02.3
+ENV BOOKSTACK_VERSION=24.02.3
 RUN apk add --no-cache curl tar
 RUN set -x; \
     curl -SL -o bookstack.tar.gz https://github.com/BookStackApp/BookStack/archive/v${BOOKSTACK_VERSION}.tar.gz  \


### PR DESCRIPTION
The issue in #479 has not been fully resolved by #481 and missed the BOOKSTACK_VERSION in Dockerfile. Therefore the Image on Docker Hub contains the Bookstack code of version 23.02.3.

This is a pull request for the missing change.