### PR TITLE
feat: update Composer to latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY bookstack.conf /etc/apache2/sites-available/000-default.conf
 
 COPY --from=bookstack --chown=33:33 /bookstack/ /var/www/bookstack/
 
-ARG COMPOSER_VERSION=2.2.23
+ARG COMPOSER_VERSION=2.7.6
 RUN set -x; \
     cd /var/www/bookstack \
     && curl -sS https://getcomposer.org/installer | php -- --version=$COMPOSER_VERSION \


### PR DESCRIPTION
Documentation states that running the latest version - rather than close to the required version - is best practise, so update that.