### PR TITLE
Correct BOOKSTACK_VERSION in Dockerfile for 24.05.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3 as bookstack
-ENV BOOKSTACK_VERSION=24.05.1
+ENV BOOKSTACK_VERSION=24.05.2
 RUN apk add --no-cache curl tar
 RUN set -x; \
     curl -SL -o bookstack.tar.gz https://github.com/BookStackApp/BookStack/archive/v${BOOKSTACK_VERSION}.tar.gz  \


### PR DESCRIPTION
#496 and #497 seem to have missed the BOOKSTACK_VERSION env var in the `Dockerfile`.

This pull requests fixes #500.