### PR TITLE
adjust php memory limit

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -1,4 +1,4 @@
 [PHP]
-
+memory_limit = 256M
 post_max_size = 10M
 upload_max_filesize = 10M


### PR DESCRIPTION
Hi, when using this container I've encountered issue while trying to see the images in gallery after an upload of another file. File uploaded was ~500KBs PNG

```
[2025-02-18 19:22:49] production.ERROR: Allowed memory size of 134217728 bytes exhausted (tried to allocate 51265720 bytes)
{"userId":16,"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Allowed memory size of 134217728 bytes
exhausted (tried to allocate 51265720 bytes) at /var/www/bookstack/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php:128)                                                                                                                                                                                            
[stacktrace]  #0 {main}"}
```

I've fixed it by building a new container with additional memory settings in php.ini as presented in change