### PR TITLE
feat: change default APP_URL value

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Note that if you want to use LDAP, `$` has to be escape like `\$`, i.e. `-e "LDA
    -e DB_DATABASE=bookstack \
    -e DB_USERNAME=bookstack \
    -e DB_PASSWORD=secret \
-   -e APP_URL=http://example.com \
+   -e APP_URL=http://localhost:8080 \
    -e APP_KEY=SomeRandomStringWith32Characters \
    -p 8080:8080 \
    --name="bookstack_25.2.1" \
@@ -84,9 +84,9 @@ Note that if you want to use LDAP, `$` has to be escape like `\$`, i.e. `-e "LDA
    ```
 
     The APP_URL parameter should be the base URL for your BookStack instance without
-    a trailing slash. For example:
+    a trailing slash, but including any port numbers. For example:
 
-    `APP_URL=http://example.com`
+    `APP_URL=http://example.com` or `APP_URL=http://localhost:8080`.
 
     The following environment variables are required for Bookstack to start:
     - `APP_KEY`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,12 @@ services:
     - DB_DATABASE=bookstack
     - DB_USERNAME=bookstack
     - DB_PASSWORD=secret
-    #set the APP_ to the URL of bookstack without without a trailing slash APP_URL=https://example.com
-    - APP_URL=http://example.com
+    # Set the APP_ to the URL of bookstack without without a trailing slash,
+    # but including any port numbers. For example, one of:
+    # APP_URL=https://example.com
+    # APP_URL=http://localhost:8080
+    # APP_URL=https://wiki.example.com:8443
+    - APP_URL=http://localhost:8080
     # APP_KEY is used for encryption where needed, so needs to be persisted to
     # preserve decryption abilities.
     # Can run `php artisan key:generate` to generate a key


### PR DESCRIPTION
Running a freshly-clone repository fails as the Bookstack container redirects to `example.com`, which isn't hosting a Bookstack instance. Updating the `APP_URL` to be the value set by default and referred to in the documention will prevent this.