### PR TITLE
chore: remove version specification from docker-compose files

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   sut:
     image: appropriate/curl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   mysql:
     image: mysql:9.2


### PR DESCRIPTION
The top-level version key in docker-compose files is obsolete: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete